### PR TITLE
Add support for Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,120 @@
+---
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  build:
+    name: Build afsr
+    runs-on: ${{ matrix.artifact.os }}
+    env:
+      CARGO_TERM_COLOR: always
+      # https://github.com/rust-lang/rust/issues/78210
+      RUSTFLAGS: -C strip=symbols -C target-feature=+crt-static
+      TARGETS: ${{ join(matrix.artifact.targets, ' ') || matrix.artifact.name }}
+      ANDROID_API: ${{ matrix.artifact.android_api }}
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact:
+          - os: ubuntu-latest
+            name: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            name: x86_64-pc-windows-gnu
+          - os: macos-latest
+            name: universal-apple-darwin
+            targets:
+              - aarch64-apple-darwin
+              - x86_64-apple-darwin
+            combine: lipo
+          # ubuntu-latest is not 24.04 yet and 22.04's qemu-user-static segfaults.
+          - os: ubuntu-24.04
+            name: aarch64-linux-android31
+            targets:
+              - aarch64-linux-android
+            android_api: '31'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # For git describe
+          fetch-depth: 0
+
+      - name: Install cargo-android
+        shell: bash
+        run: |
+          cargo install \
+              --git https://github.com/chenxiaolong/cargo-android \
+              --tag v0.1.2
+
+      - name: Get version
+        id: get_version
+        shell: bash
+        run: |
+          echo -n 'version=' >> "${GITHUB_OUTPUT}"
+          git describe --always \
+              | sed -E "s/^v//g;s/([^-]*-g)/r\1/;s/-/./g" \
+              >> "${GITHUB_OUTPUT}"
+
+      - name: Install toolchains
+        shell: bash
+        run: |
+          for target in ${TARGETS}; do
+              rustup target add "${target}"
+          done
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Clippy
+        shell: bash
+        run: |
+          for target in ${TARGETS}; do
+              cargo android \
+                  clippy --release --features static \
+                  --target "${target}"
+          done
+
+      - name: Formatting
+        run: cargo fmt -- --check
+
+      - name: Build
+        shell: bash
+        run: |
+          for target in ${TARGETS}; do
+              cargo android \
+                  build --release --features static \
+                  --target "${target}"
+          done
+
+      - name: Create output directory
+        shell: bash
+        run: |
+          rm -rf target/output
+
+          case "${{ matrix.artifact.combine }}" in
+          lipo)
+              mkdir target/output
+              cmd=(lipo -output target/output/afsr -create)
+              for target in ${TARGETS}; do
+                  cmd+=("target/${target}/release/afsr")
+              done
+              "${cmd[@]}"
+              ;;
+          '')
+              ln -s "${TARGETS}/release" target/output
+              ;;
+          *)
+              echo >&2 "Unsupported combine argument"
+              exit 1
+              ;;
+          esac
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: afsr-${{ steps.get_version.outputs.version }}-${{ matrix.artifact.name }}
+          path: |
+            target/output/afsr
+            target/output/afsr.exe

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,17 @@
+---
+name: cargo-deny
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  check:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+---
+on:
+  push:
+    # Uncomment to test against a branch
+    #branches:
+    #  - ci
+    tags:
+      - 'v*'
+jobs:
+  create_release:
+    name: Create Github release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Get version from tag
+        id: get_version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              version=${GITHUB_REF#refs/tags/v}
+          else
+              version=0.0.0.${GITHUB_REF#refs/heads/}
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: Version ${{ steps.get_version.outputs.version }}
+          body_path: RELEASE.md
+          draft: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/e2fsprogs"]
+	path = external/e2fsprogs
+	url = https://android.googlesource.com/platform/external/e2fsprogs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "bindgen",
  "bstr",
  "cap-std",
+ "cc",
  "clap",
  "jiff",
  "num-traits",
@@ -163,6 +164,16 @@ dependencies = [
  "io-extras",
  "io-lifetimes",
  "rustix",
+]
+
+[[package]]
+name = "cc"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+dependencies = [
+ "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -363,6 +374,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52113e019082508e868f92202f6e55c690c69990b17c350db01813cdf1dc1b19"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,8 @@ uuid = { version = "1.8.0", features = ["serde"] }
 
 [build-dependencies]
 bindgen = "0.69.2"
+cc = { version = "1.1.10", features = ["jobserver", "parallel"], optional = true }
 pkg-config = "0.3.30"
+
+[features]
+static = ["dep:cc"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ When packing, the ext filesystem image is created bit-for-bit reproducibly, with
 
 afsr is intended for modifying Android ext4 filesystems, but should work with arbitrary ext filesystems.
 
-**Please note that afsr is a personal project.** There are no backwards compatibility guarantees and I only intend to support filesystems used in the Android devices I own. If you depend on afsr, please consider pinning to a specific commit. I currently have no plans to provide prebuilt binaries.
+**Please note that afsr is a personal project.** I only intend to support filesystems used in the Android devices I own. If you depend on afsr, please consider pinning to a specific version.
 
 ## Features
 
@@ -181,6 +181,10 @@ Note that while AOSP's tools and afsr both build reproducible images, the output
 * The file write patterns are different so the lifetime writes field in the ext superblock (`s_kbytes_written`) will have a different value.
 * For symlinks with a long target path, afsr allocates the inode before the data block that stores the target path. e2fsdroid follows upstream e2fsprogs behavior and does the reverse.
 * afsr always allocates an entry's inode once and attempts to link it a second time if `EXT2_ET_DIR_NO_SPACE` is encountered and a directory needs to be expanded. e2fsdroid follows the upstream e2fsprogs behavior and may retry the whole process (including inode allocation) when a directory runs out of space.
+
+## Verifying digital signatures
+
+To verify the digital signatures of the downloads, follow [the steps here](https://github.com/chenxiaolong/chenxiaolong/blob/master/VERIFY_SSH_SIGNATURES.md).
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+The changelog can be found at: [`CHANGELOG.md`](./CHANGELOG.md).
+
+---
+
+See [`README.md`](./README.md) for information on how to use afsr and how to verify the digital signatures of the downloads.

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,186 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::{env, path::PathBuf};
 
-use pkg_config::Library;
+/// This intentionally tries to mirror Android.bp as closely as possible.
+///
+/// NOTE: Not all of e2fsprogs is under a license compatible with afsr's GPLv3
+/// license. We should only link to the library components that are under LGPLv2
+/// since those are compatible with GPLv3.
+#[cfg(feature = "static")]
+fn build_e2fs() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target = env::var("TARGET").unwrap();
 
-fn utf8_path_str(path: &Path) -> &str {
+    if target_os == "windows" && target.ends_with("_msvc") {
+        panic!("e2fsprogs does not support MSVC");
+    }
+
+    let mut builder = cc::Build::new();
+
+    // We can't bind to inline functions.
+    builder.define("NO_INLINE_FUNCS", None);
+
+    // Android.bp
+    builder.flag("-Wall");
+    builder.flag("-Werror");
+    builder.flag("-Wno-pointer-arith");
+    builder.flag("-Wno-sign-compare");
+    builder.flag("-Wno-type-limits");
+    builder.flag("-Wno-typedef-redefinition");
+    builder.flag("-Wno-unused-parameter");
+    if target_os == "macos" {
+        builder.flag("-Wno-error=deprecated-declarations");
+    } else if target_os == "windows" {
+        builder.include("external/e2fsprogs/include/mingw");
+    }
+
+    // lib/Android.bp
+    builder.include("external/e2fsprogs/lib");
+
+    // lib/e2p/Android.bp
+    builder.file("external/e2fsprogs/lib/e2p/encoding.c");
+    builder.file("external/e2fsprogs/lib/e2p/errcode.c");
+    builder.file("external/e2fsprogs/lib/e2p/feature.c");
+    builder.file("external/e2fsprogs/lib/e2p/fgetflags.c");
+    builder.file("external/e2fsprogs/lib/e2p/fsetflags.c");
+    builder.file("external/e2fsprogs/lib/e2p/fgetproject.c");
+    builder.file("external/e2fsprogs/lib/e2p/fsetproject.c");
+    builder.file("external/e2fsprogs/lib/e2p/fgetversion.c");
+    builder.file("external/e2fsprogs/lib/e2p/fsetversion.c");
+    builder.file("external/e2fsprogs/lib/e2p/getflags.c");
+    builder.file("external/e2fsprogs/lib/e2p/getversion.c");
+    builder.file("external/e2fsprogs/lib/e2p/hashstr.c");
+    builder.file("external/e2fsprogs/lib/e2p/iod.c");
+    builder.file("external/e2fsprogs/lib/e2p/ljs.c");
+    builder.file("external/e2fsprogs/lib/e2p/ls.c");
+    builder.file("external/e2fsprogs/lib/e2p/mntopts.c");
+    builder.file("external/e2fsprogs/lib/e2p/parse_num.c");
+    builder.file("external/e2fsprogs/lib/e2p/pe.c");
+    builder.file("external/e2fsprogs/lib/e2p/pf.c");
+    builder.file("external/e2fsprogs/lib/e2p/ps.c");
+    builder.file("external/e2fsprogs/lib/e2p/setflags.c");
+    builder.file("external/e2fsprogs/lib/e2p/setversion.c");
+    builder.file("external/e2fsprogs/lib/e2p/uuid.c");
+    builder.file("external/e2fsprogs/lib/e2p/ostype.c");
+    builder.file("external/e2fsprogs/lib/e2p/percent.c");
+
+    // lib/et/Android.bp
+    builder.include("external/e2fsprogs/lib/et");
+    builder.file("external/e2fsprogs/lib/et/error_message.c");
+    builder.file("external/e2fsprogs/lib/et/et_name.c");
+    builder.file("external/e2fsprogs/lib/et/init_et.c");
+    builder.file("external/e2fsprogs/lib/et/com_err.c");
+    builder.file("external/e2fsprogs/lib/et/com_right.c");
+
+    // lib/ext2fs/Android.bp
+    builder.include("external/e2fsprogs/lib/ext2fs");
+    builder.file("external/e2fsprogs/lib/ext2fs/ext2_err.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/alloc.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/alloc_sb.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/alloc_stats.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/alloc_tables.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/atexit.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/badblocks.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/bb_inode.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/bitmaps.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/bitops.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/blkmap64_ba.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/blkmap64_rb.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/blknum.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/block.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/bmap.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/check_desc.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/crc16.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/crc32c.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/csum.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/closefs.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/dblist.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/dblist_dir.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/digest_encode.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/dirblock.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/dirhash.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/dir_iterate.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/dupfs.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/expanddir.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/ext_attr.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/extent.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/fallocate.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/fileio.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/finddev.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/flushb.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/freefs.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/gen_bitmap.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/gen_bitmap64.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/get_num_dirs.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/get_pathname.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/getsize.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/getsectsize.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/hashmap.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/i_block.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/icount.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/imager.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/ind_block.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/initialize.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/inline.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/inline_data.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/inode.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/io_manager.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/ismounted.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/link.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/llseek.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/lookup.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/mmp.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/mkdir.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/mkjournal.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/namei.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/native.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/newdir.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/nls_utf8.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/openfs.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/progress.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/punch.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/qcow2.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/rbtree.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/read_bb.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/read_bb_file.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/res_gdt.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/rw_bitmaps.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/sha256.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/sha512.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/swapfs.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/symlink.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/undo_io.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/unlink.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/valid_blk.c");
+    builder.file("external/e2fsprogs/lib/ext2fs/version.c");
+    // We don't support reading Android sparse files.
+    // builder.file("external/e2fsprogs/lib/ext2fs/sparse_io.c");
+    // Not needed.
+    // builder.file("external/e2fsprogs/lib/ext2fs/test_io.c")
+    if target_os == "windows" {
+        builder.file("external/e2fsprogs/lib/ext2fs/windows_io.c");
+    } else {
+        builder.file("external/e2fsprogs/lib/ext2fs/unix_io.c");
+    }
+
+    if target_os == "windows" {
+        builder.flag("-Wno-maybe-uninitialized");
+        builder.flag("-Wno-stringop-truncation");
+    }
+
+    builder.compile("e2fs");
+}
+
+#[cfg(feature = "static")]
+fn apply_bind_args(builder: bindgen::Builder) -> bindgen::Builder {
+    builder
+        .clang_arg("-Iexternal/e2fsprogs/lib")
+        .clang_arg("-Iexternal/e2fsprogs/lib/e2p")
+        .clang_arg("-Iexternal/e2fsprogs/lib/et")
+        .clang_arg("-Iexternal/e2fsprogs/lib/ext2fs")
+}
+
+#[cfg(not(feature = "static"))]
+fn utf8_path_str(path: &std::path::Path) -> &str {
     let Some(s) = path.to_str() else {
         panic!("Path is not valid UTF-8: {path:?}");
     };
@@ -13,7 +188,8 @@ fn utf8_path_str(path: &Path) -> &str {
     s
 }
 
-fn pkg_config_flags(library: &Library) -> impl Iterator<Item = String> + '_ {
+#[cfg(not(feature = "static"))]
+fn pkg_config_flags(library: &pkg_config::Library) -> impl Iterator<Item = String> + '_ {
     let define_flags = library.defines.iter().map(|(key, value)| {
         if let Some(v) = value {
             format!("-D{key}={v}")
@@ -29,18 +205,23 @@ fn pkg_config_flags(library: &Library) -> impl Iterator<Item = String> + '_ {
     define_flags.chain(include_flags)
 }
 
-fn main() {
+#[cfg(not(feature = "static"))]
+fn apply_bind_args(builder: bindgen::Builder) -> bindgen::Builder {
     let com_err = pkg_config::probe_library("com_err").unwrap();
     let e2p = pkg_config::probe_library("e2p").unwrap();
     let ext2fs = pkg_config::probe_library("ext2fs").unwrap();
 
-    println!("cargo:rerun-if-changed=wrapper.h");
-
-    let bindings = bindgen::Builder::default()
-        .header("wrapper.h")
+    builder
         .clang_args(pkg_config_flags(&com_err))
         .clang_args(pkg_config_flags(&e2p))
         .clang_args(pkg_config_flags(&ext2fs))
+}
+
+fn bind_e2fs() {
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let bindings = apply_bind_args(bindgen::Builder::default())
+        .header("wrapper.h")
         .clang_arg("-DNO_INLINE_FUNCS")
         .allowlist_function(".*_error_table")
         .allowlist_function("e2p_.*")
@@ -60,4 +241,11 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Failed to write bindings");
+}
+
+fn main() {
+    #[cfg(feature = "static")]
+    build_e2fs();
+
+    bind_e2fs();
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,43 @@
+[advisories]
+version = 2
+yanked = "deny"
+
+[licenses]
+version = 2
+include-dev = true
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "GPL-3.0",
+    "ISC",
+    "MIT",
+    "Unicode-DFS-2016",
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[bans]
+multiple-versions = "warn"
+multiple-versions-include-dev = true
+deny = [
+    # https://github.com/serde-rs/serde/issues/2538
+    { name = "serde_derive", version = ">=1.0.172,<1.0.184" },
+]
+
+[bans.build]
+executables = "deny"
+include-dependencies = true
+include-workspace = true
+bypass = [
+    { name = "libloading", allow-globs = ["tests/nagisa*.dll"] },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -226,7 +226,16 @@ fn populate_image(path: &Path, fs_info: &FsInfo, tree: &Dir, verbose: u8) -> Res
                     .with_context(|| format!("Failed to open file: {:?}", HostPath(&disk_path)))?;
                 let size = reader
                     .metadata()
-                    .map(|m| m.size())
+                    .map(|m| {
+                        #[cfg(unix)]
+                        {
+                            m.size()
+                        }
+                        #[cfg(windows)]
+                        {
+                            m.file_size()
+                        }
+                    })
                     .with_context(|| format!("Failed to stat file: {:?}", HostPath(&disk_path)))?;
 
                 let ino = fs


### PR DESCRIPTION
For Windows, only mingw is supported due to e2fsprogs' limitations.

Similar to avbroot and Custota, I'll provide prebuilt binaries for GNU/Linux (x86_64), Android (aarch64), Windows (x86_64), and macOS (universal: x86_64 + aarch64).

Issue: #2
