### PR TITLE
Fix compilation on Linux aarch64 and Windows

### DIFF
--- a/src/pack.rs
+++ b/src/pack.rs
@@ -226,7 +226,16 @@ fn populate_image(path: &Path, fs_info: &FsInfo, tree: &Dir, verbose: u8) -> Res
                     .with_context(|| format!("Failed to open file: {:?}", HostPath(&disk_path)))?;
                 let size = reader
                     .metadata()
-                    .map(|m| m.size())
+                    .map(|m| {
+                        #[cfg(unix)]
+                        {
+                            m.size()
+                        }
+                        #[cfg(windows)]
+                        {
+                            m.file_size()
+                        }
+                    })
                     .with_context(|| format!("Failed to stat file: {:?}", HostPath(&disk_path)))?;
 
                 let ino = fs


### PR DESCRIPTION
* Use c_char, since chars can be u8 or i8, depending on platform
* Cast error constants to errcode_t since bindgen-generated macro constants could be u32 or i32, depending on platform