### PR TITLE
Set Windows code page to UTF-8 to support Unicode paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "cap-std",
  "cc",
  "clap",
+ "embed-manifest",
  "jiff",
  "num-traits",
  "pkg-config",
@@ -251,6 +252,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "embed-manifest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cd446c890d6bed1d8b53acef5f240069ebef91d6fae7c5f52efe61fe8b5eae"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ uuid = { version = "1.8.0", features = ["serde"] }
 [build-dependencies]
 bindgen = "0.70.0"
 cc = { version = "1.1.10", features = ["jobserver", "parallel"], optional = true }
+embed-manifest = "1.4.0"
 pkg-config = "0.3.30"
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 use std::{env, path::PathBuf};
 
+use embed_manifest::{embed_manifest, new_manifest};
+
 /// This intentionally tries to mirror Android.bp as closely as possible.
 ///
 /// Unlike non-static builds, when we create a static build, we include mke2fs
@@ -316,9 +318,20 @@ fn bind_e2fs() {
         .expect("Failed to write bindings");
 }
 
+fn add_manifest() {
+    // The default settings are sensible. The only thing we actually care about
+    // is setting the code page to UTF-8 because e2fsprogs can't accept wchar_t
+    // paths.
+    if env::var_os("CARGO_CFG_WINDOWS").is_some() {
+        embed_manifest(new_manifest("Chiller3.Afsr")).expect("Failed to embed exe manifest");
+    }
+}
+
 fn main() {
     #[cfg(feature = "static")]
     build_e2fs();
 
     bind_e2fs();
+
+    add_manifest();
 }


### PR DESCRIPTION
e2fsprogs doesn't support `wchar_t *` paths, so the only way to support Unicode paths is to set the code page to UTF-8.

Fixes: #7