### PR TITLE
Expose Rust 1.83's newly stabilized io::ErrorKinds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      - name: Update Rust
+        run: rustup update stable
+
       - name: Install cargo-android
         shell: bash
         run: |


### PR DESCRIPTION
The useful errors remaining that we can't translate are `EXT2_ET_SYMLINK_LOOP` and `EXT2_ET_EXTENT_CYCLE` since the `io::ErrorKind` equivalent of `ELOOP` is not yet stabilized.